### PR TITLE
extended object name length

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
 in older versions). Please take into account.
 
 [2016-12-12]: Compile.sh has been modified. Now to create input data
-files from samples run the compile.sh with key -s
+files from samples run the compile.sh simply. If you want to use your
+own input data files run compile.sh with key -s
 
 **Please note that if you use other programs to create input data files
 you must keep "fortran" double precision format (e.g. use "d" exponent)**

--- a/README.md
+++ b/README.md
@@ -20,13 +20,10 @@ and answer "yes" for the question about creating sample files.
 THIS VERSION OF MERCURY6 PACKAGE WAS MODIFIED BY I. DOVGALEV
 TO PROVIDE TRUE DOUBLE PRECISION CALCULATIONS. ALSO, THE INITIAL DATA
 FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
-FOR ANY QUESTIONS ABOUT THIS MODIFICATION PLEASE CONTACT WITH ME USING
-THIS E-MAIL:
-idovgalyov@4xxi.com
                                                             2016-12-05
-NEW UPDATE: Provided length for object names is now 25 (instead of 8 in
-older versions). Please take into account
-                                                            2016-12-08
+
+[2016-12-08]: Provided length for object names is now 25 (instead of 8
+in older versions). Please take into account.
 -----------------------------------------------------------------------
 -----------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@ and answer "yes" for the question about creating sample files.
 THIS VERSION OF MERCURY6 PACKAGE WAS MODIFIED BY I. DOVGALEV
 TO PROVIDE TRUE DOUBLE PRECISION CALCULATIONS. ALSO, THE INITIAL DATA
 FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
-                                                            2016-12-05
+**2016-12-05**
 
 [2016-12-08]: Provided length for object names is now 25 (instead of 8
 in older versions). Please take into account.
+
+[2016-12-12]: Compile.sh has been modified. Now to create input data
+files from samples run the compile.sh with key -s
+
+**Please note that if you use other programs to create input data files
+you must keep "fortran" double precision format (e.g. use "d" exponent)**
+
 -----------------------------------------------------------------------
 -----------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ TO PROVIDE TRUE DOUBLE PRECISION CALCULATIONS. ALSO, THE INITIAL DATA
 FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
 FOR ANY QUESTIONS ABOUT THIS MODIFICATION PLEASE CONTACT WITH ME USING
 THIS E-MAIL:
-idovgalyov@4xxi.com                                         2016-12-05
+idovgalyov@4xxi.com
+                                                            2016-12-05
+NEW UPDATE: Provided length for object names is now 25 (instead of 8 in
+older versions). Please take into account
+                                                            2016-12-08
 -----------------------------------------------------------------------
 -----------------------------------------------------------------------
 

--- a/close6.for
+++ b/close6.for
@@ -28,7 +28,7 @@ c
       logical test
       character*250 string,fout,header,infile(50)
       character*80 mem(NMESS),cc,c(NMAX)
-      character*8 master_id(NMAX),id(NMAX)
+      character*25 master_id(NMAX),id(NMAX)
       character*5 fin
       character*1 check,style,type,c1
 c
@@ -98,8 +98,8 @@ c Read in the names of the objects for which orbital elements are required
 c
 c Either open an aei file for this object or put it on the waiting list
         nmaster = nmaster + 1
-        itmp = min(7,lim(2,1)-lim(1,1))
-        master_id(nmaster)='        '
+        itmp = min(24,lim(2,1)-lim(1,1))
+        master_id(nmaster)='                         '
         master_id(nmaster)(1:itmp+1) = string(lim(1,1):lim(1,1)+itmp)
         if (nopen.lt.NFILES) then
           nopen = nopen + 1
@@ -170,7 +170,7 @@ c
 c Read in strings containing compressed data for each object
           do j = 1, nbig + nsml
             line_num = line_num + 1
-            read (10,'(a)',err=666) c(j)(1:51)
+            read (10,'(a)',err=666) c(j)(1:68)
           end do
 c
 c Create input format list
@@ -184,8 +184,8 @@ c
 c For each object decompress its name, code number, mass, spin and density
           do j = 1, nbig + nsml
             k = int(.5d0 + mio_c2re(c(j)(1:8),0.d0,11239424.d0,3))
-            id(k) = c(j)(4:11)
-            m(k)  = mio_c2fl (c(j)(12:19)) * K2
+            id(k) = c(j)(4:28)
+            m(k)  = mio_c2fl (c(j)(29:36)) * K2
 c
 c Find the object on the master list
             unit(k) = 0
@@ -358,24 +358,24 @@ c------------------------------------------------------------------------------
 c
       if (timestyle.eq.0.or.timestyle.eq.2) then
         header(1:19) = '    Time (days)    '
-        header(20:58) = '  Object   dmin (AU)     a1       e1    '
-        header(59:90) = '   i1       a2       e2       i2'
-        lenhead = 90
-        fout = '(1x,f18.5,1x,a8,1x,f10.8,2(1x,f9.4,1x,f8.6,1x,f7.3))'
+        header(20:65) = '  Object                    dmin (AU)     a1  '
+        header(66:108) = '    e1       i1       a2       e2       i2'
+        lenhead = 107
+        fout = '(1x,f18.5,1x,a25,1x,f10.8,2(1x,f9.4,1x,f8.6,1x,f7.3))'
       else
         if (timestyle.eq.1) then
           header(1:23) = '     Year/Month/Day    '
-          header(24:62) = '  Object   dmin (AU)     a1       e1    '
-          header(63:94) = '   i1       a2       e2       i2'
-          lenhead = 94
-          fout(1:37) = '(1x,i10,1x,i2,1x,f8.5,1x,a8,1x,f10.8,'
-          fout(38:64) = '2(1x,f9.4,1x,f8.6,1x,f7.3))'
+          header(24:67) = '  Object                    dmin (AU)     a1'
+          header(68:112)='      e1       i1       a2       e2       i2'
+          lenhead = 111
+          fout(1:38) = '(1x,i10,1x,i2,1x,f8.5,1x,a25,1x,f10.8,'
+          fout(39:65) = '2(1x,f9.4,1x,f8.6,1x,f7.3))'
         else
           header(1:19) = '    Time (years)   '
-          header(20:58) = '  Object   dmin (AU)     a1       e1    '
-          header(59:90) = '   i1       a2       e2       i2'
-          fout = '(1x,f18.7,1x,a8,1x,f10.8,2(1x,f9.4,1x,f8.6,1x,f7.3))'
-          lenhead = 90
+          header(20:63) = '  Object                    dmin (AU)     a1'
+          header(64:107) ='      e1       i1       a2       e2       i2'
+          fout = '(1x,f18.7,1x,a25,1x,f10.8,2(1x,f9.4,1x,f8.6,1x,f7.3))'
+          lenhead = 107
         end if
       end if
 c
@@ -788,7 +788,7 @@ c
 c Input/Output
       integer unitnum,lenhead,lmem(NMESS)
       character*4 extn
-      character*8 id
+      character*25 id
       character*250 header
       character*80 mem(NMESS)
 c
@@ -803,8 +803,8 @@ c
       data bad/ '*', '/', '.', ':', '&'/
 c
 c Create a filename based on the object's name
-      call mio_spl (8,id,nsub,lim)
-      itmp = min(7,lim(2,1)-lim(1,1))
+      call mio_spl (25,id,nsub,lim)
+      itmp = min(24,lim(2,1)-lim(1,1))
       filename(1:itmp+1) = id(1:itmp+1)
       filename(itmp+2:itmp+5) = extn
       do j = itmp + 6, 250
@@ -826,7 +826,7 @@ c If the file exists already, give a warning and don't overwrite it
         unitnum = -1
       else
         open (unitnum, file=filename, status='new')
-        write (unitnum, '(/,30x,a8,//,a)') id,header(1:lenhead)
+        write (unitnum, '(/,30x,a25,//,a)') id,header(1:lenhead)
       end if
 c
 c------------------------------------------------------------------------------

--- a/compile.sh
+++ b/compile.sh
@@ -4,11 +4,16 @@ gfortran element6.for -o element6
 gfortran close6.for -o close6
 gfortran mercury6_2.for -o mercury6
 
-echo "Create sample data files? (yes/no)"
-read create_samples
-
-if [ $create_samples = 'yes' ] ; then
-  for i in *.sample; do
-    cp $i `echo $i | sed 's/.sample//g'`
-  done
+if [ "$1" != "-s" ]; then
+    for i in *.sample; do
+        cp $i `echo $i | sed 's/.sample//g'`
+    done
+#else
+#    echo "Create input data files from samples? (yes/no)"
+#    read create_samples
+#    if [ $create_samples = 'yes' || $create_samples = 'y'] ; then
+#        for i in *.sample; do
+#            cp $i `echo $i | sed 's/.sample//g'`
+#        done
+#    fi
 fi

--- a/compile.sh
+++ b/compile.sh
@@ -8,12 +8,4 @@ if [ "$1" != "-s" ]; then
     for i in *.sample; do
         cp $i `echo $i | sed 's/.sample//g'`
     done
-#else
-#    echo "Create input data files from samples? (yes/no)"
-#    read create_samples
-#    if [ $create_samples = 'yes' || $create_samples = 'y'] ; then
-#        for i in *.sample; do
-#            cp $i `echo $i | sed 's/.sample//g'`
-#        done
-#    fi
 fi

--- a/element.in.sample
+++ b/element.in.sample
@@ -13,8 +13,8 @@
  express time relative to integration start time = yes
 )---------------------------------------------------------------------
 ) Output format? (e.g. a8.4 => semi-major axis with 8 digits & 4 dec. places)
-) p13e l13.5e a8.5 e8.6 i8.4 g8.4 n8.4 m13e 
- a21.16 x21.16 y21.16 z21.16
+ p13e l13.5e a8.5 e8.6 i8.4 g8.4 n8.4 m13e 
+) a21.16 x21.16 y21.16 z21.16
 )---------------------------------------------------------------------
 ) Which bodies do you not want? (List one per line or leave blank for all bodies)
 )

--- a/element.in.sample
+++ b/element.in.sample
@@ -8,7 +8,7 @@
 )---------------------------------------------------------------------
  type of elements (central body, barycentric, Jacobi) = Central
 ) minimum interval between outputs (days) = 365.2d1
- minimum interval between outputs (days) = 90d0
+ minimum interval between outputs (days) = 100d1
  express time in days or years = years
  express time relative to integration start time = yes
 )---------------------------------------------------------------------

--- a/element6.for
+++ b/element6.for
@@ -30,7 +30,7 @@ c
       logical test
       character*250 string,fout,header,infile(50)
       character*80 mem(NMESS),cc,c(NMAX)
-      character*8 master_id(NMAX),id(NMAX)
+      character*25 master_id(NMAX),id(NMAX)
       character*5 fin
       character*1 check,style,type,c1
       character*2 c2
@@ -123,8 +123,8 @@ c Read in the names of the objects for which orbital elements are required
 c
 c Either open an aei file for this object or put it on the waiting list
         nmaster = nmaster + 1
-        itmp = min(7,lim(2,1)-lim(1,1))
-        master_id(nmaster)='        '
+        itmp = min(25,lim(2,1)-lim(1,1))
+        master_id(nmaster)='                         '
         master_id(nmaster)(1:itmp+1) = string(lim(1,1):lim(1,1)+itmp)
         if (nopen.lt.NFILES) then
           nopen = nopen + 1
@@ -191,7 +191,7 @@ c
 c Read in strings containing compressed data for each object
           do j = 1, nbig + nsml
             line_num = line_num + 1
-            read (10,'(a)',err=666) c(j)(1:51)
+            read (10,'(a)',err=666) c(j)(1:68)
           end do
 c
 c Create input format list
@@ -205,12 +205,12 @@ c
 c For each object decompress its name, code number, mass, spin and density
           do j = 1, nbig + nsml
             k = int(.5d0 + mio_c2re(c(j)(1:8),0.d0,11239424.d0,3))
-            id(k) = c(j)(4:11)
-            el(18,k) = mio_c2fl (c(j)(12:19))
-            s(1) = mio_c2fl (c(j)(20:27))
-            s(2) = mio_c2fl (c(j)(28:35))
-            s(3) = mio_c2fl (c(j)(36:43))
-            el(21,k) = mio_c2fl (c(j)(44:51))
+            id(k) = c(j)(4:28)
+            el(18,k) = mio_c2fl (c(j)(29:36))
+            s(1) = mio_c2fl (c(j)(37:44))
+            s(2) = mio_c2fl (c(j)(45:52))
+            s(3) = mio_c2fl (c(j)(53:60))
+            el(21,k) = mio_c2fl (c(j)(61:68))
 c
 c Calculate spin rate and longitude & inclination of spin vector
             temp = sqrt(s(1)*s(1) + s(2)*s(2) + s(3)*s(3))
@@ -472,7 +472,8 @@ c
 c------------------------------------------------------------------------------
 c
 c Format statements
- 213  format (1x,a8,1x,f8.4,1x,f7.5,1x,f7.3,1p,e11.4,0p,1x,f6.3,1x,f6.2)
+ 213  format (1x,a25,1x,f8.4,1x,f7.5,1x,f7.3,
+     % 1p,e11.4,0p,1x,f6.3,1x,f6.2)
 c
       end
 c
@@ -932,7 +933,7 @@ c
 c Input/Output
       integer unitnum,lenhead,lmem(NMESS)
       character*4 extn
-      character*8 id
+      character*25 id
       character*250 header
       character*80 mem(NMESS)
 c
@@ -947,8 +948,8 @@ c
       data bad/ '*', '/', '.', ':', '&'/
 c
 c Create a filename based on the object's name
-      call mio_spl (8,id,nsub,lim)
-      itmp = min(7,lim(2,1)-lim(1,1))
+      call mio_spl (25,id,nsub,lim)
+      itmp = min(24,lim(2,1)-lim(1,1))
       filename(1:itmp+1) = id(1:itmp+1)
       filename(itmp+2:itmp+5) = extn
       do j = itmp + 6, 250
@@ -970,7 +971,7 @@ c If the file exists already, give a warning and don't overwrite it
         unitnum = -1
       else
         open (unitnum, file=filename, status='new')
-        write (unitnum, '(/,30x,a8,//,a)') id,header(1:lenhead)
+        write (unitnum, '(/,30x,a25,//,a)') id,header(1:lenhead)
       end if
 c
 c------------------------------------------------------------------------------

--- a/mercury6.man
+++ b/mercury6.man
@@ -1,4 +1,6 @@
 				   
+
+
 -----------------------------------------------------------------------
 -----------------------------------------------------------------------
 THIS VERSION OF MERCURY6 PACKAGE WAS MODIFIED BY I. DOVGALEV
@@ -6,7 +8,11 @@ TO PROVIDE TRUE DOUBLE PRECISION CALCULATIONS. ALSO, THE INITIAL DATA
 FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
 FOR ANY QUESTIONS ABOUT THIS MODIFICATION PLEASE CONTACT WITH ME USING
 THIS E-MAIL:
-idovgalyov@4xxi.com                                         2016-12-05
+idovgalyov@4xxi.com
+                                                            2016-12-05
+NEW UPDATE: Provided length for object names is now 25 (instead of 8 in
+older versions). Please take into account
+                                                            2016-12-08
 -----------------------------------------------------------------------
 -----------------------------------------------------------------------
 

--- a/mercury6.man
+++ b/mercury6.man
@@ -6,10 +6,17 @@
 THIS VERSION OF MERCURY6 PACKAGE WAS MODIFIED BY I. DOVGALEV
 TO PROVIDE TRUE DOUBLE PRECISION CALCULATIONS. ALSO, THE INITIAL DATA
 FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
-                                                            2016-12-05
+**2016-12-05**
 
 [2016-12-08]: Provided length for object names is now 25 (instead of 8
 in older versions). Please take into account.
+
+[2016-12-12]: Compile.sh has been modified. Now to create input data
+files from samples run the compile.sh with key -s
+
+**Please note that if you use other programs to create input data files
+you must keep "fortran" double precision format (e.g. use "d" exponent)**
+
 -----------------------------------------------------------------------
 -----------------------------------------------------------------------
 

--- a/mercury6.man
+++ b/mercury6.man
@@ -6,13 +6,10 @@
 THIS VERSION OF MERCURY6 PACKAGE WAS MODIFIED BY I. DOVGALEV
 TO PROVIDE TRUE DOUBLE PRECISION CALCULATIONS. ALSO, THE INITIAL DATA
 FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
-FOR ANY QUESTIONS ABOUT THIS MODIFICATION PLEASE CONTACT WITH ME USING
-THIS E-MAIL:
-idovgalyov@4xxi.com
                                                             2016-12-05
-NEW UPDATE: Provided length for object names is now 25 (instead of 8 in
-older versions). Please take into account
-                                                            2016-12-08
+
+[2016-12-08]: Provided length for object names is now 25 (instead of 8
+in older versions). Please take into account.
 -----------------------------------------------------------------------
 -----------------------------------------------------------------------
 

--- a/mercury6.man
+++ b/mercury6.man
@@ -12,7 +12,8 @@ FOR PLANETS IN "big.in" FILE WAS UPDATED (see http://ssd.jpl.nasa.gov).
 in older versions). Please take into account.
 
 [2016-12-12]: Compile.sh has been modified. Now to create input data
-files from samples run the compile.sh with key -s
+files from samples run the compile.sh simply. If you want to use your
+own input data files run compile.sh with key -s
 
 **Please note that if you use other programs to create input data files
 you must keep "fortran" double precision format (e.g. use "d" exponent)**

--- a/mercury6_2.for
+++ b/mercury6_2.for
@@ -37,7 +37,7 @@ c  S      = spin angular momentum (solar masses AU^2/day)
 c  RHO    = physical density (g/cm^3)
 c  RCEH   = close-encounter limit (Hill radii)
 c  STAT   = status (0 => alive, <>0 => to be removed)
-c  ID     = name of the object (8 characters)
+c  ID     = name of the object (25 characters)
 c  CE     = close encounter status
 c  NGF    = (1-3) cometary non-gravitational (jet) force parameters
 c   "     =  (4)  beta parameter for radiation pressure and P-R drag
@@ -117,7 +117,7 @@ c
       real*8 m(NMAX),xh(3,NMAX),vh(3,NMAX),s(3,NMAX),rho(NMAX)
       real*8 rceh(NMAX),epoch(NMAX),ngf(4,NMAX),rmax,rcen,jcen(3)
       real*8 cefac,time,tstart,tstop,dtout,h0,tol,en(3),am(3)
-      character*8 id(NMAX)
+      character*25 id(NMAX)
       character*80 outfile(3), dumpfile(4), mem(NMESS)
       external mdt_mvs, mdt_bs1, mdt_bs2, mdt_ra15, mdt_hy
       external mco_dh2h,mco_h2dh
@@ -280,7 +280,7 @@ c Input/Output
       real*8 time,tstart,tstop,dtout,h0,tol,jcen(3),rcen,rmax
       real*8 en(3),am(3),cefac,m(nbod),xh(3,nbod),vh(3,nbod)
       real*8 s(3,nbod),rho(nbod),rceh(nbod),ngf(4,nbod)
-      character*8 id(nbod)
+      character*25 id(nbod)
       character*80 outfile(3),dumpfile(4),mem(NMESS)
 c
 c Local
@@ -534,7 +534,7 @@ c Input/Output
       real*8 time,tstart,tstop,dtout,h0,tol,jcen(3),rcen,rmax
       real*8 en(3),am(3),cefac,m(nbod),xh(3,nbod),vh(3,nbod)
       real*8 s(3,nbod),rho(nbod),rceh(nbod),ngf(4,nbod)
-      character*8 id(nbod)
+      character*25 id(nbod)
       character*80 outfile(3),dumpfile(4),mem(NMESS)
 c
 c Local
@@ -995,7 +995,7 @@ c Input/Output
       real*8 time,tstart,elost,jcen(3)
       real*8 m(nbod),xh(3,nbod),vh(3,nbod),s(3,nbod),rphys(nbod)
       character*80 outfile,mem(NMESS)
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer year,month,itmp
@@ -1021,10 +1021,10 @@ c
       if (opt(3).eq.1) then
         call mio_jd2y (time,year,month,t1)
         if (i.eq.0) then
-          flost = '(1x,a8,a,i10,1x,i2,1x,f8.5)'
+          flost = '(1x,a25,a,i10,1x,i2,1x,f8.5)'
           write (23,flost) id(j),mem(67)(1:lmem(67)),year,month,t1
         else
-          fcol  = '(1x,a8,a,a8,a,i10,1x,i2,1x,f4.1)'
+          fcol  = '(1x,a25,a,a25,a,i10,1x,i2,1x,f4.1)'
           write (23,fcol) id(i),mem(69)(1:lmem(69)),id(j),
      %      mem(71)(1:lmem(71)),year,month,t1
         end if
@@ -1032,14 +1032,14 @@ c
         if (opt(3).eq.3) then
           t1 = (time - tstart) / 365.25d0
           tstring = mem(2)
-          flost = '(1x,a8,a,f18.7,a)'
-          fcol  = '(1x,a8,a,a8,a,1x,f14.3,a)'
+          flost = '(1x,a25,a,f18.7,a)'
+          fcol  = '(1x,a25,a,a25,a,1x,f14.3,a)'
         else
           if (opt(3).eq.0) t1 = time
           if (opt(3).eq.2) t1 = time - tstart
           tstring = mem(1)
-          flost = '(1x,a8,a,f18.5,a)'
-          fcol  = '(1x,a8,a,a8,a,1x,f14.1,a)'
+          flost = '(1x,a25,a,f18.5,a)'
+          fcol  = '(1x,a25,a,a25,a,1x,f14.1,a)'
         end if
         if (i.eq.0.or.i.eq.1) then
           write (23,flost) id(j),mem(67)(1:lmem(67)),t1,tstring
@@ -1149,7 +1149,7 @@ c Input/Output
       real*8 tstart,h,jcen(3),rcen,rmax,cefac,m(nbod),x(3,nbod)
       real*8 v(3,nbod),s(3,nbod),rho(nbod),rceh(nbod),rphys(nbod)
       real*8 rce(nbod),rcrit(nbod)
-      character*8 id(nbod)
+      character*25 id(nbod)
       character*80 outfile
 c
 c Local
@@ -1198,12 +1198,12 @@ c Write list of object's identities to close-encounter output file
 c
       do j = 2, nbod
         c(j)(1:8) = mio_re2c (dble(j - 1), 0.d0, 11239423.99d0)
-        c(j)(4:11) = id(j)
-        c(j)(12:19) = mio_fl2c (m(j) * k_2)
-        c(j)(20:27) = mio_fl2c (s(1,j) * k_2)
-        c(j)(28:35) = mio_fl2c (s(2,j) * k_2)
-        c(j)(36:43) = mio_fl2c (s(3,j) * k_2)
-        c(j)(44:51) = mio_fl2c (rho(j) / rhocgs)
+        c(j)(4:28) = id(j)
+        c(j)(29:36) = mio_fl2c (m(j) * k_2)
+        c(j)(37:44) = mio_fl2c (s(1,j) * k_2)
+        c(j)(45:52) = mio_fl2c (s(2,j) * k_2)
+        c(j)(53:60) = mio_fl2c (s(3,j) * k_2)
+        c(j)(61:68) = mio_fl2c (rho(j) / rhocgs)
       end do
 c
 c Write compressed output to file
@@ -1211,7 +1211,7 @@ c Write compressed output to file
       write (22,'(a1,a2,i2,a62,i1)') char(12),'6a',algor,header(1:62),
      %  opt(4)
       do j = 2, nbod
-        write (22,'(a51)') c(j)(1:51)
+        write (22,'(a68)') c(j)(1:68)
       end do
       close (22)
 c
@@ -3403,7 +3403,7 @@ c Input/Output
       real*8 rce(nbod),rcrit(nbod),ngf(4,nbod),tclo(CMAX),dclo(CMAX)
       real*8 ixvclo(6,CMAX),jxvclo(6,CMAX)
       character*80 outfile(3),mem(NMESS)
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer j,nce,ice(NMAX),jce(NMAX),ce(NMAX),iflag
@@ -3560,7 +3560,7 @@ c Input/Output
       real*8 rce(nbod),rphy(nbod),rcrit(nbod),ngf(4,nbod)
       real*8 tclo(CMAX),dclo(CMAX),ixvclo(6,CMAX),jxvclo(6,CMAX)
       character*80 outfile(3),mem(NMESS)
-      character*8 id(nbod)
+      character*25 id(nbod)
       external force
 c
 c Local
@@ -3572,7 +3572,7 @@ c Local
       real*8 rcritbs(NMAX),rcebs(NMAX),rphybs(NMAX)
       real*8 ngfbs(4,NMAX),x0(3,NMAX),v0(3,NMAX)
       real*8 thit(CMAX),dhit(CMAX),thit1,temp
-      character*8 idbs(NMAX)
+      character*25 idbs(NMAX)
 c
 c------------------------------------------------------------------------------
 c
@@ -3717,7 +3717,7 @@ c Input/Output
       real*8 rce(nbod),rcrit(nbod),ngf(4,nbod),tclo(CMAX),dclo(CMAX)
       real*8 ixvclo(6,CMAX),jxvclo(6,CMAX)
       character*80 outfile(3),mem(NMESS)
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer j,iflag,nhit,ihit(CMAX),jhit(CMAX),chit(CMAX),nowflag
@@ -5099,7 +5099,7 @@ c Input/Output
       real*8 time,tstart,rcen,rmax,m(nbod),tclo(nclo),dclo(nclo)
       real*8 ixvclo(6,nclo),jxvclo(6,nclo)
       character*80 outfile(3),mem(NMESS)
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer k,year,month
@@ -5220,7 +5220,7 @@ c Input/Output
       real*8 jcen(3),rcen,cefac,m(nbod),x(3,nbod),v(3,nbod)
       real*8 s(3,nbod),rho(nbod),rceh(nbod),ngf(4,nbod),epoch(nbod)
       character*80 dumpfile(4),mem(NMESS)
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer idp,i,j,k,len1,j1,j2
@@ -5269,9 +5269,9 @@ c Write header lines, data style (and epoch for Big bodies)
 c
 c For each body...
           do j = j1, j2
-            len1 = 37
-            c(1:8) = id(j)
-            write (c(9:37),'(1p,a3,e11.5,a3,e11.5)') ' r=',rceh(j),
+            len1 = 54
+            c(1:25) = id(j)
+            write (c(26:54),'(1p,a3,e11.5,a3,e11.5)') ' r=',rceh(j),
      %        ' d=',rho(j)/rhocgs
             if (m (j).gt.0d0) then
               write (c(len1+1:len1+25),'(a3,e22.15)') ' m=',m(j)*k_2
@@ -5554,7 +5554,7 @@ c Input/Output
       real*8 en(3),am(3),m(NMAX),x(3,NMAX),v(3,NMAX),s(3,NMAX)
       real*8 rho(NMAX),rceh(NMAX),epoch(NMAX),ngf(4,NMAX),cefac
       character*80 outfile(3),dumpfile(4), mem(NMESS)
-      character*8 id(NMAX)
+      character*25 id(NMAX)
 c
 c Local
       integer j,k,itmp,jtmp,informat,lim(2,10),nsub,year,month,lineno
@@ -5811,7 +5811,7 @@ c
           write (23,'(/,3a)') mem(121)(1:lmem(121)),
      %      mem(122)(1:lmem(122)),string( lim(1,1):lim(2,1) )
         end if
-        id(nbod) = string( lim(1,1):min(7+lim(1,1),lim(2,1)) )
+        id(nbod) = string( lim(1,1):min(24+lim(1,1),lim(2,1)) )
 c Check if another object has the same name
         do k = 1, nbod - 1
           if (id(k).eq.id(nbod)) call mio_err (23,mem(81),lmem(81),
@@ -6320,7 +6320,7 @@ c Input/Output
       real*8 time,jcen(3),rcen,rmax,m(nbod),xh(3,nbod),vh(3,nbod)
       real*8 s(3,nbod),rho(nbod)
       character*80 outfile
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer k, len1, nchar
@@ -6373,19 +6373,19 @@ c For each object, compress its index number, name, mass, spin components
 c and density (some of these need to be converted to normal units).
         do k = 2, nbod
           c(k)(1:8) = mio_re2c (dble(k - 1), 0.d0, 11239423.99d0)
-          c(k)(4:11) = id(k)
-          c(k)(12:19) = mio_fl2c (m(k) * k_2)
-          c(k)(20:27) = mio_fl2c (s(1,k) * k_2)
-          c(k)(28:35) = mio_fl2c (s(2,k) * k_2)
-          c(k)(36:43) = mio_fl2c (s(3,k) * k_2)
-          c(k)(44:51) = mio_fl2c (rho(k) / rhocgs)
+          c(k)(4:28) = id(k)
+          c(k)(29:36) = mio_fl2c (m(k) * k_2)
+          c(k)(37:44) = mio_fl2c (s(1,k) * k_2)
+          c(k)(45:52) = mio_fl2c (s(2,k) * k_2)
+          c(k)(53:60) = mio_fl2c (s(3,k) * k_2)
+          c(k)(61:68) = mio_fl2c (rho(k) / rhocgs)
         end do
 c
 c Write compressed output to file
         write (21,'(a1,a2,i2,a62,i1)') char(12),'6a',algor,header(1:62),
      %    opt(4)
         do k = 2, nbod
-          write (21,'(a51)') c(k)(1:51)
+          write (21,'(a68)') c(k)(1:68)
         end do
       end if
 c
@@ -6579,7 +6579,7 @@ c Input/Output
       real*8 time, tstart, rmax, en(3), am(3), jcen(3)
       real*8 m(nbod), x(3,nbod), v(3,nbod), s(3,nbod)
       character*80 outfile, mem(NMESS)
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer j, year, month
@@ -6611,18 +6611,18 @@ c Write message to information file
   20      open  (23,file=outfile,status='old',access='append',err=20)
           if (opt(3).eq.1) then
             call mio_jd2y (time,year,month,t1)
-            flost = '(1x,a8,a,i10,1x,i2,1x,f8.5)'
+            flost = '(1x,a25,a,i10,1x,i2,1x,f8.5)'
             write (23,flost) id(j),mem(68)(1:lmem(68)),year,month,t1
           else
             if (opt(3).eq.3) then
               t1 = (time - tstart) / 365.25d0
               tstring = mem(2)
-              flost = '(1x,a8,a,f18.7,a)'
+              flost = '(1x,a25,a,f18.7,a)'
             else
               if (opt(3).eq.0) t1 = time
               if (opt(3).eq.2) t1 = time - tstart
               tstring = mem(1)
-              flost = '(1x,a8,a,f18.5,a)'
+              flost = '(1x,a25,a,f18.5,a)'
             end if
             write (23,flost) id(j),mem(68)(1:lmem(68)),t1,tstring
           end if
@@ -6665,7 +6665,7 @@ c Input/Output
       integer nbod, nbig, nelim, stat(nbod), lmem(NMESS)
       real*8 m(nbod), x(3,nbod), v(3,nbod), s(3,nbod)
       real*8 rho(nbod), rceh(nbod), rcrit(nbod), ngf(4,nbod)
-      character*8 id(nbod)
+      character*25 id(nbod)
       character*80 outfile, mem(NMESS)
 c
 c Local
@@ -6983,14 +6983,14 @@ c Input/Output
       integer nbod,nbig,ngflag,opt(8),stat(nbod)
       real*8 time,tstart,h0,tol,jcen(3),m(nbod),x(3,nbod),v(3,nbod)
       real*8 s(3,nbod),rceh(nbod),rho(nbod),epoch(nbod),ngf(4,nbod)
-      character*8 id(nbod)
+      character*25 id(nbod)
 c
 c Local
       integer j,k,l,nsml,nsofar,indx(NMAX),itemp,jtemp(NMAX)
       integer raflag,nce,ice(NMAX),jce(NMAX)
       real*8 temp,epsml(NMAX),rtemp(NMAX)
       real*8 h,hdid,tsmall,rphys(NMAX),rcrit(NMAX)
-      character*8 ctemp(NMAX)
+      character*25 ctemp(NMAX)
       external mfo_all
 c
 c------------------------------------------------------------------------------


### PR DESCRIPTION
Provided length for object names is now 25 (instead of 8 in older versions).
It is made because some asteroids have names with more than 8 symbols.
Updated ReadMe's.