### PR TITLE
runtime optimization keys

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -9,7 +9,7 @@ rm *.dmp *.clo *.out *.tmp *.aei
 echo "Delete compiled files? (yes/no)"
 read need_delete
 
-if [ $need_delete = 'yes' ]; then
+if [ $need_delete = 'yes' ] || [ $need_delete = 'y' ]; then
   echo "Compiled files are deleted"
   if [ -e 'close6' ]; then
     rm close6
@@ -25,7 +25,7 @@ fi
 echo "Delete input files? (yes/no)"
 read need_delete_input
 
-if [ $need_delete_input = 'yes' ]; then
+if [ $need_delete_input = 'yes' ] || [ $need_delete_input = 'y' ]; then
   echo "Deleting input files"
   rm *.in
 fi

--- a/compile.sh
+++ b/compile.sh
@@ -1,8 +1,8 @@
 echo "Compiling mercury6 package"
 
-gfortran element6.for -o element6
-gfortran close6.for -o close6
-gfortran mercury6_2.for -o mercury6
+gfortran -O2 element6.for -o element6
+gfortran -O2 close6.for -o close6
+gfortran -O2 mercury6_2.for -o mercury6
 
 if [ "$1" != "-s" ]; then
     for i in *.sample; do


### PR DESCRIPTION
Included -O2 keys in "gfortran" commands in "compile.sh".
That must significantly increase the speed of integrtion.
No changes in output (at least in my tests).
Also made some changes in "clean.sh" (it now supports "y" answers along with "yes").