### PR TITLE
Bugfix: IEEE invalid operation when checking for central body collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # --- constants
 FORTRAN=gfortran
-FFLAGS=-g -O2 -Wline-truncation -Wsurprising -Werror
+FFLAGS=-g -O2 -Wline-truncation -Wsurprising -Werror -ffpe-trap=invalid,zero,overflow
 BIN=.
 EXEC=.
 SRC=.

--- a/mercury6_2.for
+++ b/mercury6_2.for
@@ -960,7 +960,18 @@ c Time of impact relative to the end of the timestep
             if (e.lt.1d0) then
               a = q / (1.d0 - e)
               uhit = sign (acos((1.d0 - rcen/a)/e), -h)
-              u0   = sign (acos((1.d0 - r0/a  )/e), rv0)
+c Avoid invalid acos calls (due to previous rounding errors) by checking input
+c             u0   = sign (acos((1.d0 - r0/a  )/e), rv0)
+              temp = (1.d0 - r0/a)/e
+              if (temp.ge.1d0) then
+                u0 = 0.d0
+              else
+                if (temp.le.-1d0) then
+                  u0 = sign(PI, rv0)
+                else
+                  u0 = sign(acos(temp), rv0)
+                end if
+              end if
               mhit = mod (uhit - e*sin(uhit) + PI, TWOPI) - PI
               m0   = mod (u0   - e*sin(u0)   + PI, TWOPI) - PI
             else


### PR DESCRIPTION
Hi all,

I sometimes stumble across the following warning message when running Mercury:

`Note: The following floating-point exceptions are signalling: IEEE_INVALID_FLAG`

With not much more to go on, I added the gfortran compiler flag `-ffpe-trap=invalid` to find the problem: calling acos() for a value less than -1, for which acos is not defined. Here is the part (line 963 in mercury6_2.for):

`u0   = sign (acos((1.d0 - r0/a  )/e), rv0)`

I assumed that it was a rounding issue, since the values I got when checking were -1.0000000000288831 and -1.0000000002232341 (all at high e), but I don't understand all of the variabls exactly so I can't be 100% sure. I therefore added a check for the value before passing it on to acos, and setting the boundary values when a value is outside the (-1, 1) range. I also added the compiler flags to the Makefile to make sure people will catch more of these bugs when/if they occur.

Hope that helps someone!
Cheers